### PR TITLE
new package: app-emulation/{nemu-xiangshan,nemu-nju}

### DIFF
--- a/app-emulation/nemu-xiangshan/files/nemu-xiangshan-add-syncconfig.patch
+++ b/app-emulation/nemu-xiangshan/files/nemu-xiangshan-add-syncconfig.patch
@@ -1,0 +1,14 @@
+diff --git a/scripts/config.mk b/scripts/config.mk
+index 7b85f49..f8d994e 100644
+--- a/scripts/config.mk
++++ b/scripts/config.mk
+@@ -26,6 +26,9 @@ $(MCONF):
+ $(FIXDEP):
+ 	$(Q)$(MAKE) $(silent) -C $(FIXDEP_PATH)
+ 
++syncconfig: $(CONF) $(FIXDEP)
++	$(Q)$(CONF) $(silent) --syncconfig $(Kconfig)
++
+ menuconfig: $(MCONF) $(CONF) $(FIXDEP)
+ 	$(Q)$(MCONF) $(Kconfig)
+ 	$(Q)$(CONF) $(silent) --syncconfig $(Kconfig)

--- a/app-emulation/nemu-xiangshan/files/nemu-xiangshan-disable-git-tracking.patch
+++ b/app-emulation/nemu-xiangshan/files/nemu-xiangshan-disable-git-tracking.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/git.mk b/scripts/git.mk
+index 5400e61..8e0a353 100644
+--- a/scripts/git.mk
++++ b/scripts/git.mk
+@@ -7,8 +7,4 @@ GITFLAGS = -q --author='tracer-ics2021 <tracer@njuics.org>' --no-verify --allow-
+ 
+ # prototype: git_commit(msg)
+ define git_commit
+-	-@git add $(NEMU_HOME)/.. -A --ignore-errors
+-	-@while (test -e .git/index.lock); do sleep 0.1; done
+-	-@(echo "> $(1)" && echo $(STUID) && hostnamectl && uptime) | git commit -F - $(GITFLAGS)
+-	-@sync
+ endef

--- a/app-emulation/nemu-xiangshan/metadata.xml
+++ b/app-emulation/nemu-xiangshan/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <!-- maintainer-needed -->
+  <upstream>
+    <remote-id type="github">OpenXiangShan/NEMU</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/app-emulation/nemu-xiangshan/metadata.xml
+++ b/app-emulation/nemu-xiangshan/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <!-- maintainer-needed -->
+  <maintainer type="person" proxied="yes">
+    <email>alex.fan.q@gmail.com</email>
+    <name>Alex Fan</name>
+  </maintainer>
+  <maintainer type="project" proxied="proxy">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
   <upstream>
     <remote-id type="github">OpenXiangShan/NEMU</remote-id>
   </upstream>

--- a/app-emulation/nemu-xiangshan/nemu-xiangshan-9999.ebuild
+++ b/app-emulation/nemu-xiangshan/nemu-xiangshan-9999.ebuild
@@ -35,8 +35,7 @@ inherit savedconfig readme.gentoo-r1
 DESCRIPTION="NJU EMUlator, a full system x86/mips32/riscv32/riscv64 emulator for teaching"
 HOMEPAGE="https://github.com/OpenXiangShan/NEMU"
 
-# no license specified in upstream
-LICENSE="GPL-2"
+LICENSE="MulanPSL-2.0"
 SLOT="0"
 IUSE="savedconfig"
 

--- a/app-emulation/nemu-xiangshan/nemu-xiangshan-9999.ebuild
+++ b/app-emulation/nemu-xiangshan/nemu-xiangshan-9999.ebuild
@@ -1,0 +1,124 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISABLE_AUTOFORMATTING="true"
+DOC_CONTENTS='
+		nemu-xiangshan mini config HOWTO
+
+Note: nemu-xiangshan is configurable via mconf, like the linux kernel.
+Without user config, this ebuild will target minimum riscv64
+You are encouraged to configure it on your own. Here are a couple of ways:
+
+1) USE="-savedconfig" and set/unset the remaining flags to obtain the features
+you want, and possibly a lot more.
+
+2) You can create your own configuration file by doing:
+
+FEATURES="keepwork" USE="savedconfig -*" emerge nemu-xiangshan
+cd /var/tmp/portage/app-emulation/nemu-xiangshan*/work/nemu-xiangshan*
+make menuconfig
+
+Now configure nemu-xiangshan as you want.  Finally save your config file:
+
+cp config/.config /etc/portage/savedconfig/app-emulation/nemu-xiangshan-${PV}
+
+where ${PV} is the current version.  You can then run emerge again with
+your configuration by doing:
+
+USE="savedconfig" emerge nemu-xiangshan
+'
+
+inherit savedconfig readme.gentoo-r1
+
+DESCRIPTION="NJU EMUlator, a full system x86/mips32/riscv32/riscv64 emulator for teaching"
+HOMEPAGE="https://github.com/OpenXiangShan/NEMU"
+
+# no license specified in upstream
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="savedconfig"
+
+EGIT_REPO_URI="https://github.com/OpenXiangShan/NEMU.git"
+EGIT_SUBMODULES=(
+	ready-to-run
+)
+inherit git-r3
+
+DEPEND="
+	sys-apps/dtc
+	media-libs/libsdl2
+	sys-libs/zlib
+	sys-libs/readline:=
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-disable-git-tracking.patch
+	"${FILESDIR}"/${PN}-add-syncconfig.patch
+)
+
+QA_PREBUILT="
+	usr/share/${PN}/ready-to-run/coremark-2-iteration.bin
+	usr/share/${PN}/ready-to-run/linux.bin
+	usr/share/${PN}/ready-to-run/riscv64-nemu-interpreter-dual-so
+	usr/share/${PN}/ready-to-run/linux-0xa0000.bin
+	usr/share/${PN}/ready-to-run/microbench.bin
+	usr/share/${PN}/ready-to-run/riscv64-nemu-interpreter-so
+"
+
+src_prepare() {
+	default
+	sed -i -e "/^CCACHE/d" scripts/build.mk || die
+}
+
+src_configure() {
+	export NEMU_HOME="${PWD}"
+	if use savedconfig; then
+		restore_config .config
+		if [[ -f .config ]]; then
+			ewarn "Using saved config"
+		else
+			die "No saved config, please consider generate one with 'make menuconfig'"
+		fi
+	else
+		elog "No saved config, seeding minimum riscv64"
+		cp configs/riscv64-xs_defconfig .config || die
+	fi
+
+	emake -j1 syncconfig < <(yes '') > /dev/null
+}
+
+src_compile() {
+	export NEMU_HOME="${PWD}"
+	emake
+	# TODO: require cross-compilation
+	# cd resource/gcpt_restore || die
+	# emake
+}
+
+src_install() {
+	dodoc README.md
+	dodoc -r resource/debian
+	dodoc -r resource/sdcard
+	readme.gentoo_create_doc
+
+	insinto "/usr/share/${PN}/"
+	rm -r ready-to-run/.git || die
+	doins -r ready-to-run
+	# Disallow stripping of prebuilt images
+	dostrip -x ${QA_PREBUILT}
+
+	cd build || die
+	for binary in $(ls -1 2>/dev/null); do
+		IFS='-' read -a name <<<"${binary}" || die
+		if [[ "${name[1]}" == 'nemu' ]]; then
+			newbin "${binary}" "${name[0]}-nemu-xiangshan-${name[@]:2}"
+		fi
+	done
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}

--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -1,0 +1,1 @@
+OSI-APPROVED MulanPSL-2.0


### PR DESCRIPTION
The NJU emulator (nemu) has two versions, the NJU version and Xiangshan's forked version. Binaries are renamed to avoid collision between the two.

Some features (abstract-machine and grpc-restore) are not built in the ebuild because it requires cross-compilation.

nemu uses mconf just like the kernel, so it has many configurable options. Users are encouraged to use their own saved config, but note that the ebuild will check if use flags and saved configs are consistent, or else it will raise helpful errors to prompt you.

nemu-xiangshan should be okay for all ARCHs. But nemu-nju[abstract-machine] only works on amd64 because ARCH=native (abstract-machine's variable, not gentoo's ARCH) only have amd64 implementation. All other values need cross-compilation