### PR TITLE
app-emulation/spike: fix spike-9999

### DIFF
--- a/app-emulation/spike/spike-9999.ebuild
+++ b/app-emulation/spike/spike-9999.ebuild
@@ -1,21 +1,30 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="8"
-inherit autotools git-r3 multilib
+EAPI=8
 
 DESCRIPTION="The RISC-V ISA Simulator"
-HOMEPAGE="https://github.com/riscv/riscv-isa-sim/"
-EGIT_REPO_URI="https://github.com/riscv-software-src/riscv-isa-sim"
+HOMEPAGE="https://github.com/riscv-software-src/riscv-isa-sim"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
 IUSE=""
 
-DEPEND=""
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/riscv-software-src/riscv-isa-sim.git"
+else
+	SRC_URI="https://github.com/riscv-software-src/riscv-isa-sim/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/${PN}-${COMMIT}"
+	KEYWORDS="~amd64"
+fi
+
+DEPEND="sys-apps/dtc"
+RDEPEND="${DEPEND}"
+BDEPEND=""
 
 src_prepare() {
 	default
-	sed -i -e "/install_libs_dir/s:/lib:/$(get_libdir):g" Makefile.in || die
-	eautoreconf
+
+	sed -i -e "/install_libs_dir/s:/lib:/$(get_libdir)/spike:g" Makefile.in || die
 }


### PR DESCRIPTION
`eautoreconf` doesn't seem to be necessary here and would break Makefile.in, causing the build to fail.
Spike depends on dtc but at the same time installs libfdt.so, which causes a file collision with sys-apps/dtc. I fixed it simply by adding dependency on dtc and  substituting $(get_libdir)/spike for install_libs_dir, although I'm not sure if it's a good fix or not.